### PR TITLE
Instantiate quantizer specified only by name

### DIFF
--- a/qkeras/safe_eval.py
+++ b/qkeras/safe_eval.py
@@ -83,4 +83,4 @@ def safe_eval(eval_str, op_dict, *params, **kwparams):  # pylint: disable=invali
   if len(function_split) == 2 or args or kwargs:
     return quantizer(*args, **kwargs)
   else:
-    return quantizer
+    return quantizer()

--- a/tests/qconvolutional_test.py
+++ b/tests/qconvolutional_test.py
@@ -30,8 +30,6 @@ from qkeras import QDense
 from qkeras import QConv1D
 from qkeras import QConv2D
 from qkeras import QSeparableConv2D
-from qkeras import binary
-from qkeras import ternary
 from qkeras import quantized_bits
 from qkeras.utils import model_save_quantized_weights
 from qkeras.utils import quantized_model_from_json
@@ -42,7 +40,7 @@ def test_qnetwork():
   x = QSeparableConv2D(
       32, (2, 2),
       strides=(2, 2),
-      depthwise_quantizer=binary(),
+      depthwise_quantizer="binary",
       pointwise_quantizer=quantized_bits(4, 0, 1),
       depthwise_activation=quantized_bits(6, 2, 1),
       bias_quantizer=quantized_bits(4, 0, 1),
@@ -52,7 +50,7 @@ def test_qnetwork():
   x = QConv2D(
       64, (3, 3),
       strides=(2, 2),
-      kernel_quantizer=ternary(),
+      kernel_quantizer="ternary",
       bias_quantizer=quantized_bits(4, 0, 1),
       name='conv2d_1_m')(
           x)

--- a/tests/safe_eval_test.py
+++ b/tests/safe_eval_test.py
@@ -58,7 +58,7 @@ def myadd2(a, b):
   return i_func(a) + i_func(b)
 
 
-def myadd(a=0, b=0):
+def myadd(a=32, b=10):
   return a + b
 
 
@@ -76,6 +76,9 @@ def test_safe_eval4():
   assert safe_eval("myadd2(a= 39)", globals(), b=3) == -42
   assert safe_eval("myadd2(a= 39, b = 3)", globals()) == -42
 
+def test_safe_eval5():
+  assert safe_eval("myadd", globals()) == 42
+  assert safe_eval("myadd()", globals()) == 42
 
 if __name__ == "__main__":
   pytest.main([__file__])


### PR DESCRIPTION
Instantiate quantizer without arguments if only specified by name (i.e., treat `binary` as `binart()`). Test case included