### PR TITLE
Return a function instead of calling it (in safe_eval)

### DIFF
--- a/qkeras/safe_eval.py
+++ b/qkeras/safe_eval.py
@@ -84,6 +84,8 @@ def safe_eval(eval_str, op_dict, *params, **kwparams):  # pylint: disable=invali
     return quantizer(*args, **kwargs)
   else:
     if isinstance(quantizer, type):
+      # Check if quantizer is a class
       return quantizer()
     else:
+      # Otherwise it is a function, so just return it
       return quantizer

--- a/qkeras/safe_eval.py
+++ b/qkeras/safe_eval.py
@@ -83,4 +83,7 @@ def safe_eval(eval_str, op_dict, *params, **kwparams):  # pylint: disable=invali
   if len(function_split) == 2 or args or kwargs:
     return quantizer(*args, **kwargs)
   else:
-    return quantizer()
+    if isinstance(quantizer, type):
+      return quantizer()
+    else:
+      return quantizer

--- a/tests/safe_eval_test.py
+++ b/tests/safe_eval_test.py
@@ -61,6 +61,9 @@ def myadd2(a, b):
 def myadd(a=32, b=10):
   return a + b
 
+class myaddcls(object):
+  def __call__(self, a=32, b=10):
+    return a + b
 
 def test_safe_eval2():
   s_add = [3, 39]
@@ -68,6 +71,7 @@ def test_safe_eval2():
 
 
 def test_safe_eval3():
+  assert safe_eval("myadd()", globals()) == 42
   assert safe_eval("myadd(a=39)", globals(), b=3) == 42
 
 
@@ -77,8 +81,9 @@ def test_safe_eval4():
   assert safe_eval("myadd2(a= 39, b = 3)", globals()) == -42
 
 def test_safe_eval5():
-  assert safe_eval("myadd", globals()) == 42
-  assert safe_eval("myadd()", globals()) == 42
+  assert safe_eval("myadd", globals())(3,39) == 42
+  assert safe_eval("myaddcls", globals())(3,39) == 42
+  assert safe_eval("myaddcls()", globals())(3,39) == 42
 
 if __name__ == "__main__":
   pytest.main([__file__])


### PR DESCRIPTION
If quantizer is a function (like `binary_tanh` or `hard_sigmoid`, used as activations), `safe_eval` would try to make an instance of it and fail. This was due to the change introduced in #12. We should check if quantizer is class to be instantiated before being called or a function ready to be called.