### PR TITLE
Add support for loading qkeras models h5 file obtained from Keras's model.save()

### DIFF
--- a/qkeras/utils.py
+++ b/qkeras/utils.py
@@ -401,7 +401,7 @@ def model_quantize(model,
 
 def _add_supported_quantized_objects(custom_objects):
 
-  #Map all the quantized objects
+  # Map all the quantized objects
   custom_objects["QDense"] = QDense
   custom_objects["QConv1D"] = QConv1D
   custom_objects["QConv2D"] = QConv2D
@@ -427,7 +427,6 @@ def quantized_model_from_json(json_string, custom_objects=None):
   if not custom_objects:
     custom_objects = {}
 
-
   # let's make a deep copy to make sure our objects are not shared elsewhere
   custom_objects = copy.deepcopy(custom_objects)
 
@@ -437,7 +436,7 @@ def quantized_model_from_json(json_string, custom_objects=None):
 
   return qmodel
 
-def load_qmodel(filepath, custom_objects=None, compile = True):
+def load_qmodel(filepath, custom_objects=None, compile=True):
   """
   Load quantized model from Keras's model.save() h5 file.
 
@@ -470,6 +469,6 @@ def load_qmodel(filepath, custom_objects=None, compile = True):
     
   _add_supported_quantized_objects(custom_objects)
     
-  qmodel = tf.keras.models.load_model(filepath, custom_objects=custom_objects, compile = compile)
+  qmodel = tf.keras.models.load_model(filepath, custom_objects=custom_objects, compile=compile)
     
   return qmodel

--- a/qkeras/utils.py
+++ b/qkeras/utils.py
@@ -399,14 +399,9 @@ def model_quantize(model,
 
   return qmodel, custom_objects
 
+def _add_supported_quantized_objects(custom_objects):
 
-def quantized_model_from_json(json_string, custom_objects=None):
-  if not custom_objects:
-    custom_objects = {}
-
-  # let's make a deep copy to make sure our objects are not shared elsewhere
-  custom_objects = copy.deepcopy(custom_objects)
-
+  #Map all the quantized objects
   custom_objects["QDense"] = QDense
   custom_objects["QConv1D"] = QConv1D
   custom_objects["QConv2D"] = QConv2D
@@ -426,6 +421,17 @@ def quantized_model_from_json(json_string, custom_objects=None):
   custom_objects["quantized_tanh"] = quantized_tanh
   custom_objects["quantized_po2"] = quantized_po2
   custom_objects["quantized_relu_po2"] = quantized_relu_po2
+
+
+def quantized_model_from_json(json_string, custom_objects=None):
+  if not custom_objects:
+    custom_objects = {}
+
+
+  # let's make a deep copy to make sure our objects are not shared elsewhere
+  custom_objects = copy.deepcopy(custom_objects)
+
+  _add_supported_quantized_objects(custom_objects)
 
   qmodel = model_from_json(json_string, custom_objects=custom_objects)
 
@@ -462,25 +468,7 @@ def load_qmodel(filepath, custom_objects=None, compile = True):
   # let's make a deep copy to make sure our objects are not shared elsewhere
   custom_objects = copy.deepcopy(custom_objects)
     
-  custom_objects["QDense"] = QDense
-  custom_objects["QConv1D"] = QConv1D
-  custom_objects["QConv2D"] = QConv2D
-  custom_objects["QDepthwiseConv2D"] = QDepthwiseConv2D
-  custom_objects["QAveragePooling2D"] = QAveragePooling2D
-  custom_objects["QActivation"] = QActivation
-  custom_objects["QBatchNormalization"] = QBatchNormalization
-  custom_objects["Clip"] = Clip
-  custom_objects["quantized_bits"] = quantized_bits
-  custom_objects["bernoulli"] = bernoulli
-  custom_objects["stochastic_ternary"] = stochastic_ternary
-  custom_objects["ternary"] = ternary
-  custom_objects["stochastic_binary"] = stochastic_binary
-  custom_objects["binary"] = binary
-  custom_objects["quantized_relu"] = quantized_relu
-  custom_objects["quantized_ulaw"] = quantized_ulaw
-  custom_objects["quantized_tanh"] = quantized_tanh
-  custom_objects["quantized_po2"] = quantized_po2
-  custom_objects["quantized_relu_po2"] = quantized_relu_po2
+  _add_supported_quantized_objects(custom_objects)
     
   qmodel = tf.keras.models.load_model(filepath, custom_objects=custom_objects, compile = compile)
     

--- a/qkeras/utils.py
+++ b/qkeras/utils.py
@@ -430,3 +430,58 @@ def quantized_model_from_json(json_string, custom_objects=None):
   qmodel = model_from_json(json_string, custom_objects=custom_objects)
 
   return qmodel
+
+def load_qmodel(filepath, custom_objects=None, compile = True):
+  """
+  Load quantized model from Keras's model.save() h5 file.
+
+  # Arguments:
+        filepath: one of the following:
+                  - string, path to the saved model
+                  - h5py.File or h5py.Group object from which to load the model
+                  - any file-like object implementing the method `read` that returns
+                  `bytes` data (e.g. `io.BytesIO`) that represents a valid h5py file image.
+        custom_objects: Optional dictionary mapping names
+                  (strings) to custom classes or functions to be
+                  considered during deserialization.
+        compile: Boolean, whether to compile the model
+                  after loading.
+  
+  # Returns
+        A Keras model instance. If an optimizer was found
+        as part of the saved model, the model is already
+        compiled. Otherwise, the model is uncompiled and
+        a warning will be displayed. When `compile` is set
+        to False, the compilation is omitted without any
+        warning.
+  """
+
+  if not custom_objects:
+    custom_objects = {}
+
+  # let's make a deep copy to make sure our objects are not shared elsewhere
+  custom_objects = copy.deepcopy(custom_objects)
+    
+  custom_objects["QDense"] = QDense
+  custom_objects["QConv1D"] = QConv1D
+  custom_objects["QConv2D"] = QConv2D
+  custom_objects["QDepthwiseConv2D"] = QDepthwiseConv2D
+  custom_objects["QAveragePooling2D"] = QAveragePooling2D
+  custom_objects["QActivation"] = QActivation
+  custom_objects["QBatchNormalization"] = QBatchNormalization
+  custom_objects["Clip"] = Clip
+  custom_objects["quantized_bits"] = quantized_bits
+  custom_objects["bernoulli"] = bernoulli
+  custom_objects["stochastic_ternary"] = stochastic_ternary
+  custom_objects["ternary"] = ternary
+  custom_objects["stochastic_binary"] = stochastic_binary
+  custom_objects["binary"] = binary
+  custom_objects["quantized_relu"] = quantized_relu
+  custom_objects["quantized_ulaw"] = quantized_ulaw
+  custom_objects["quantized_tanh"] = quantized_tanh
+  custom_objects["quantized_po2"] = quantized_po2
+  custom_objects["quantized_relu_po2"] = quantized_relu_po2
+    
+  qmodel = tf.keras.models.load_model(filepath, custom_objects=custom_objects, compile = compile)
+    
+  return qmodel

--- a/tests/qconvolutional_test.py
+++ b/tests/qconvolutional_test.py
@@ -15,6 +15,7 @@
 # ==============================================================================
 """Test layers from qconvolutional.py."""
 
+import os
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
@@ -33,6 +34,7 @@ from qkeras import QSeparableConv2D
 from qkeras import quantized_bits
 from qkeras.utils import model_save_quantized_weights
 from qkeras.utils import quantized_model_from_json
+from qkeras.utils import load_qmodel
 from qkeras import print_qstats
 from qkeras import extract_model_operations
 
@@ -180,6 +182,16 @@ def test_qconv1d():
           10.0 * np.random.normal(0.0, np.sqrt(2.0 / input_size), shape))
     if all_weights:
       layer.set_weights(all_weights)
+    
+  # Save the model as an h5 file using Keras's model.save()
+  model.save("QConv1D.h5")
+  del model  # Delete the existing model
+
+  # Returns a compiled model identical to the previous one
+  model = load_qmodel('QConv1D.h5')
+
+  #Clean the created h5 file after loading the model
+  os.remove("QConv1D.h5")
 
   # apply quantizer to weights
   model_save_quantized_weights(model)

--- a/tests/qconvolutional_test.py
+++ b/tests/qconvolutional_test.py
@@ -16,6 +16,7 @@
 """Test layers from qconvolutional.py."""
 
 import os
+import tempfile
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
@@ -184,14 +185,16 @@ def test_qconv1d():
       layer.set_weights(all_weights)
     
   # Save the model as an h5 file using Keras's model.save()
-  model.save("QConv1D.h5")
+  fd, fname = tempfile.mkstemp('.h5')
+  model.save(fname)
   del model  # Delete the existing model
 
   # Returns a compiled model identical to the previous one
-  model = load_qmodel('QConv1D.h5')
+  model = load_qmodel(fname)
 
   #Clean the created h5 file after loading the model
-  os.remove("QConv1D.h5")
+  os.close(fd)
+  os.remove(fname)
 
   # apply quantizer to weights
   model_save_quantized_weights(model)


### PR DESCRIPTION
Just add another function in `qkeras.utils` called `load_qmodel`. This removes the pain of having to supply a list of custom objects every time we try to load the quantized model from `.h5` file obtained from Keras's `model.save()`