### PR TITLE
Support quantizing Sequential models

### DIFF
--- a/examples/example_keras_to_qkeras.py
+++ b/examples/example_keras_to_qkeras.py
@@ -24,7 +24,8 @@ from collections import defaultdict
 from tensorflow.keras.layers import *
 from tensorflow.keras.models import Model
 
-from qkeras import *
+from qkeras.utils import model_quantize
+from qkeras.estimate import print_qstats
 
 x = x_in = Input((32, 32, 3), name="input")
 x = Conv2D(128, (3, 3), strides=1, name="conv2d_0_m")(x)
@@ -66,7 +67,7 @@ q_dict = {
     }
 }
 
-qmodel, _ = model_quantize(model, q_dict, 4)
+qmodel = model_quantize(model, q_dict, 4)
 
 qmodel.summary()
 

--- a/qkeras/utils.py
+++ b/qkeras/utils.py
@@ -178,7 +178,7 @@ def quantize_activation(layer_config, activation_bits):
 
 def get_config(quantizer_config, layer, layer_class, parameter=None):
   """Returns search of quantizer on quantizer_config."""
-  quantizer = quantizer_config.get(layer["name"],
+  quantizer = quantizer_config.get(layer["config"]["name"],
                                    quantizer_config.get(layer_class, None))
 
   if quantizer is not None and parameter is not None:
@@ -375,7 +375,7 @@ def model_quantize(model,
       # layer name is in dictionary to enable conversion
       # otherwise we will just skip it.
       if (
-          layer["name"] not in quantizer_config and
+          layer_config["name"] not in quantizer_config and
           "QBatchNormalization" not in quantizer_config
       ):
         continue


### PR DESCRIPTION
`model_quantize` and `get_config` currently assume the layer configuration dicttionary contains `name` field, which is true for models created with functional API (i.e., `Model`). However, the `Sequential` models don't have that field, but both have it as part of the `config`, so `layer["config"]["name"]` works for both types of models.

Also included is the test case and an updated example which wasn't working before. 