### PR TITLE
Disable stochastic behavior when in inference mode

### DIFF
--- a/qkeras/quantizers.py
+++ b/qkeras/quantizers.py
@@ -648,9 +648,7 @@ class ternary(BaseQuantizer):  # pylint: disable=invalid-name
         # well for Uniform and Normal distribution of input
         v = scale * _round_through(
             x / scale,
-            use_stochastic_rounding=tf.math.logical_and(
-                tf.cast(self.use_stochastic_rounding, dtype=tf.bool),
-                tf.cast(K.learning_phase(), dtype=tf.bool)),
+            use_stochastic_rounding=self.use_stochastic_rounding,
             precision=1. / 3.)
         q = K.cast(tf.abs(v) >= thres, K.floatx()) * tf.sign(x)
         scale = _get_scale(self.alpha, x, q)
@@ -1297,8 +1295,9 @@ class quantized_tanh(BaseQuantizer):  # pylint: disable=invalid-name
     m_i = pow(2, self.integer)
     p = _sigmoid(x / m_i) * m
     xq = m_i * tf.keras.backend.clip(
-        2.0 * (_round_through(p, self.use_stochastic_rounding) / m) - \
-        1.0, -1.0 + (1.0 * self.symmetric) / m, 1.0 - 1.0 / m)
+        2.0 *
+        (_round_through(p, self.use_stochastic_rounding) / m) - 1.0, -1.0 +
+        (1.0 * self.symmetric) / m, 1.0 - 1.0 / m)
     return xq
 
   def _set_trainable_parameter(self):
@@ -1500,9 +1499,10 @@ class quantized_po2(BaseQuantizer):  # pylint: disable=invalid-name
     x_sign = tf.sign(x)
     x_sign += (1.0 - tf.abs(x_sign))
     x_abs = tf.abs(x)
-    x_clipped = _clip_power_of_two(
-        x_abs, self._min_exp, self._max_exp, self.max_value,
-        self.quadratic_approximation, self.use_stochastic_rounding)
+    x_clipped = _clip_power_of_two(x_abs, self._min_exp, self._max_exp,
+                                   self.max_value,
+                                   self.quadratic_approximation,
+                                   self.use_stochastic_rounding)
     return x + tf.stop_gradient(-x + x_sign * pow(2.0, x_clipped))
 
   def _set_trainable_parameter(self):
@@ -1596,9 +1596,10 @@ class quantized_relu_po2(BaseQuantizer):  # pylint: disable=invalid-name
       x = tf.where(
           x <= self.max_value, K.relu(x), tf.ones_like(x) * self.max_value)
 
-    x_clipped = _clip_power_of_two(
-        x, self._min_exp, self._max_exp, self.max_value,
-        self.quadratic_approximation, self.use_stochastic_rounding)
+    x_clipped = _clip_power_of_two(x, self._min_exp, self._max_exp,
+                                   self.max_value,
+                                   self.quadratic_approximation,
+                                   self.use_stochastic_rounding)
     return x + tf.stop_gradient(-x + pow(2.0, x_clipped))
 
   def _set_trainable_parameter(self):

--- a/qkeras/quantizers.py
+++ b/qkeras/quantizers.py
@@ -27,6 +27,7 @@ import tensorflow.compat.v2 as tf
 from tensorflow.keras import initializers
 import tensorflow.keras.backend as K
 from tensorflow.keras.utils import deserialize_keras_object
+from tensorflow.python.keras.utils import tf_utils
 
 from .safe_eval import safe_eval
 
@@ -218,10 +219,12 @@ def _round_through(x, use_stochastic_rounding=False, precision=0.5):
     Rounded tensor.
   """
   if use_stochastic_rounding:
-    return x + tf.stop_gradient(-x + stochastic_round(x, precision))
+    output = tf_utils.smart_cond(K.learning_phase(),
+    lambda: x + tf.stop_gradient(-x + stochastic_round(x, precision)),
+    lambda: x + tf.stop_gradient(-x + tf.round(x)))
   else:
-    return x + tf.stop_gradient(-x + tf.round(x))
-
+    output = x + tf.stop_gradient(-x + tf.round(x))
+  return output
 
 def _sign_through(x):
   """Computes the sign operation using the straight through estimator."""
@@ -248,8 +251,17 @@ def _ceil_through(x):
 # layers.
 #
 
+class BaseQuantizer(object):
+  """Base quantizer
+  
+  Defines behavior all quantizers should follow.
+  """
 
-class quantized_bits(object):  # pylint: disable=invalid-name
+  def __init__(self):
+    pass
+
+
+class quantized_bits(BaseQuantizer):  # pylint: disable=invalid-name
   """Quantizes the number to a number of bits.
 
   In general, we want to use a quantization function like:
@@ -295,6 +307,7 @@ class quantized_bits(object):  # pylint: disable=invalid-name
 
   def __init__(self, bits=8, integer=0, symmetric=0, keep_negative=1,
                alpha=None, use_stochastic_rounding=False):
+    super(quantized_bits, self).__init__()
     self.bits = bits
     self.integer = integer
     self.symmetric = symmetric
@@ -541,151 +554,7 @@ class bernoulli(object):  # pylint: disable=invalid-name
     return config
 
 
-class stochastic_ternary(object):  # pylint: disable=invalid-name
-  """Computes a stochastic activation function returning -alpha, 0 or +alpha.
-
-  Computes straight-through approximation using random sampling to make
-  E[dL/dy] = E[dL/dx], and computing the sign function. See explanation above.
-
-  Attributes:
-    x: tensor to perform sign opertion with stochastic sampling.
-    bits: number of bits to perform quantization.
-    alpha: ternary is -alpha or +alpha, or "auto" or "auto_po2".
-    threshold: (1-threshold) specifies the spread of the +1 and -1 values.
-    temperature: amplifier factor for sigmoid function, making stochastic
-      less stochastic as it moves away from 0.
-    use_real_sigmoid: use real sigmoid for probability.
-    number_of_unrolls: number of times we iterate between scale and threshold.
-
-  Returns:
-    Computation of sign with stochastic sampling with straight through gradient.
-  """
-
-  def __init__(self, alpha=None, threshold=None, temperature=8.0,
-               use_real_sigmoid=True, number_of_unrolls=5):
-    self.bits = 2
-    self.alpha = alpha
-    self.threshold = threshold
-    assert threshold != 1.0
-    self.default_alpha = 1.0
-    self.default_threshold = 0.33
-    self.temperature = temperature
-    self.use_real_sigmoid = use_real_sigmoid
-    self.number_of_unrolls = number_of_unrolls
-    self.scale = None
-
-  def __str__(self):
-    flags = []
-    if self.alpha is not None:
-      alpha = str(self.alpha)
-      if isinstance(self.alpha, six.string_types):
-        alpha = "'" + alpha + "'"
-      flags.append("alpha=" + alpha)
-    if self.threshold is not None:
-      flags.append("threshold=" + str(self.threshold))
-    if self.temperature != 8.0:
-      flags.append("temperature=" + str(self.temperature))
-    if not self.use_real_sigmoid:
-      flags.append("use_real_sigmoid=0")
-    if self.number_of_unrolls != 5:
-      flags.append("number_of_unrolls=" + str(self.number_of_unrolls))
-    return "stochastic_ternary(" + ",".join(flags) + ")"
-
-  def __call__(self, x):
-
-    if self.alpha is None:
-      scale = self.default_alpha
-    elif isinstance(self.alpha, six.string_types):
-      scale = 1.0
-      assert self.alpha in ["auto", "auto_po2"]
-    else:
-      assert self.alpha >= 0.0
-      scale = float(self.alpha)
-
-    len_axis = len(x.shape)
-    if len_axis > 1:
-      if K.image_data_format() == "channels_last":
-        axis = list(range(len_axis - 1))
-      else:
-        axis = list(range(1, len_axis))
-    else:
-      axis = [0]
-
-    x_mean = K.mean(x, axis=axis, keepdims=True)
-    x_std = K.std(x, axis=axis, keepdims=True)
-
-    m = K.max(tf.abs(x), axis=axis, keepdims=True)
-    scale = 2.*m/3.
-    if self.alpha == "auto_po2":
-      scale = K.pow(2.0,
-                    tf.math.round(K.log(scale + K.epsilon()) / np.log(2.0)))
-    for _ in range(self.number_of_unrolls):
-      T = scale / 2.0
-      q_ns = K.cast(tf.abs(x) >= T, K.floatx()) * K.sign(x)
-      scale = _get_scale(self.alpha, x, q_ns)
-
-    # To address the following issue
-    # when x == const != 0, std = 0.0, x/std = inf
-    # when x == 0, std = 0.000005, x/std =  0
-    # Solution reference:
-    # https://github.com/scikit-learn/scikit-learn/blob/7389dbac82d362f296dc2746f10e43ffa1615660/sklearn/preprocessing/data.py#L70  #pylint: disable=line-too-long
-    x_std = tf.where(x_std != 0, x_std, 1.0)
-    x_norm = x / x_std
-    T = scale / (2.0 * x_std)
-
-    if self.use_real_sigmoid:
-      p0 = tf.keras.backend.sigmoid(self.temperature * (x_norm - T))
-      p1 = tf.keras.backend.sigmoid(self.temperature * (x_norm + T))
-    else:
-      p0 = _sigmoid(self.temperature * (x_norm - T))
-      p1 = _sigmoid(self.temperature * (x_norm + T))
-    r0 = tf.random.uniform(tf.shape(p0))
-    r1 = tf.random.uniform(tf.shape(p1))
-    q0 = tf.sign(p0 - r0)
-    q0 += (1.0 - tf.abs(q0))
-    q1 = tf.sign(p1 - r1)
-    q1 += (1.0 - tf.abs(q1))
-
-    q = (q0 + q1) / 2.0
-    self.scale = scale
-    return x + tf.stop_gradient(-x + scale * q)
-
-  def _set_trainable_parameter(self):
-    if self.alpha is None:
-      self.alpha = "auto_po2"
-      if self.threshold is None:
-        self.threshold = self.default_threshold
-
-  def max(self):
-    """Get the maximum value that stochastic_ternary can respresent."""
-    if self.alpha is None or isinstance(self.alpha, six.string_types):
-      return 1.0
-    else:
-      return max(1.0, self.alpha)
-
-  def min(self):
-    """Get the minimum value that stochastic_ternary can respresent."""
-    if self.alpha is None or isinstance(self.alpha, six.string_types):
-      return -1.0
-    else:
-      return -max(1.0, self.alpha)
-
-  @classmethod
-  def from_config(cls, config):
-    return cls(**config)
-
-  def get_config(self):
-    config = {
-        "alpha": self.alpha,
-        "threshold": self.threshold,
-        "temperature": self.temperature,
-        "use_real_sigmoid": self.use_real_sigmoid,
-        "number_of_unrolls": self.number_of_unrolls
-    }
-    return config
-
-
-class ternary(object):  # pylint: disable=invalid-name
+class ternary(BaseQuantizer):  # pylint: disable=invalid-name
   """Computes an activation function returning -alpha, 0 or +alpha.
 
   Right now we assume two type of behavior. For parameters, we should
@@ -707,8 +576,9 @@ class ternary(object):  # pylint: disable=invalid-name
 
   def __init__(self, alpha=None, threshold=None, use_stochastic_rounding=False,
                number_of_unrolls=5):
-    self.alpha = alpha
+    super(ternary, self).__init__()
     self.bits = 2
+    self.alpha = alpha
     self.threshold = threshold
     self.use_stochastic_rounding = use_stochastic_rounding
     self.default_alpha = 1.0
@@ -778,7 +648,9 @@ class ternary(object):  # pylint: disable=invalid-name
         # well for Uniform and Normal distribution of input
         v = scale * _round_through(
             x / scale,
-            use_stochastic_rounding=self.use_stochastic_rounding,
+            use_stochastic_rounding=tf.math.logical_and(
+                tf.cast(self.use_stochastic_rounding, dtype=tf.bool),
+                tf.cast(K.learning_phase(), dtype=tf.bool)),
             precision=1. / 3.)
         q = K.cast(tf.abs(v) >= thres, K.floatx()) * tf.sign(x)
         scale = _get_scale(self.alpha, x, q)
@@ -788,6 +660,11 @@ class ternary(object):  # pylint: disable=invalid-name
       else:
         thres = self.threshold
       q = K.cast(tf.abs(x) >= thres, K.floatx()) * tf.sign(x)
+
+    # ternary ranges from -1 to +1, so we use tanh(x) to be a differentiable
+    # version of that.
+    if self.alpha is None:
+      x = K.tanh(x)
 
     self.scale = scale
     return x + tf.stop_gradient(-x + scale * q)
@@ -824,30 +701,42 @@ class ternary(object):  # pylint: disable=invalid-name
     return config
 
 
-class stochastic_binary(object):  # pylint: disable=invalid-name
-  """Computes a stochastic activation function returning -alpha or +alpha.
+class stochastic_ternary(ternary):  # pylint: disable=invalid-name
+  """Computes a stochastic activation function returning -alpha, 0 or +alpha.
 
   Computes straight-through approximation using random sampling to make
   E[dL/dy] = E[dL/dx], and computing the sign function. See explanation above.
 
   Attributes:
     x: tensor to perform sign opertion with stochastic sampling.
-    alpha: binary is -alpha or +alpha, or "auto" or "auto_po2".
     bits: number of bits to perform quantization.
+    alpha: ternary is -alpha or +alpha, or "auto" or "auto_po2".
+    threshold: (1-threshold) specifies the spread of the +1 and -1 values.
     temperature: amplifier factor for sigmoid function, making stochastic
-        behavior less stochastic as it moves away from 0.
-    use_real_sigmoid: use real sigmoid from tensorflow for probablity.
+      less stochastic as it moves away from 0.
+    use_real_sigmoid: use real sigmoid for probability.
+    number_of_unrolls: number of times we iterate between scale and threshold.
 
   Returns:
     Computation of sign with stochastic sampling with straight through gradient.
   """
 
-  def __init__(self, alpha=None, temperature=6.0, use_real_sigmoid=True):
+  def __init__(self, alpha=None, threshold=None, temperature=8.0,
+               use_real_sigmoid=True, number_of_unrolls=5):
+    super(stochastic_ternary, self).__init__(
+      alpha=alpha, 
+      threshold=threshold, 
+      number_of_unrolls=number_of_unrolls)
+
+    self.bits = 2
     self.alpha = alpha
-    self.bits = 1
+    self.threshold = threshold
+    assert threshold != 1.0
+    self.default_alpha = 1.0
+    self.default_threshold = 0.33
     self.temperature = temperature
     self.use_real_sigmoid = use_real_sigmoid
-    self.default_alpha = 1.0
+    self.number_of_unrolls = number_of_unrolls
     self.scale = None
 
   def __str__(self):
@@ -857,15 +746,32 @@ class stochastic_binary(object):  # pylint: disable=invalid-name
       if isinstance(self.alpha, six.string_types):
         alpha = "'" + alpha + "'"
       flags.append("alpha=" + alpha)
-    if self.temperature != 6.0:
+    if self.threshold is not None:
+      flags.append("threshold=" + str(self.threshold))
+    if self.temperature != 8.0:
       flags.append("temperature=" + str(self.temperature))
     if not self.use_real_sigmoid:
-      flags.append("use_real_sigmoid=" + str(int(self.use_real_sigmoid)))
-    return "stochastic_binary(" + ",".join(flags) + ")"
+      flags.append("use_real_sigmoid=0")
+    if self.number_of_unrolls != 5:
+      flags.append("number_of_unrolls=" + str(self.number_of_unrolls))
+    return "stochastic_ternary(" + ",".join(flags) + ")"
 
   def __call__(self, x):
-    if isinstance(self.alpha, six.string_types):
+    def stochastic_output():
+      # right now we only accept alpha = "auto" or "auto_po2"
+
+      assert isinstance(self.alpha, six.string_types)
       assert self.alpha in ["auto", "auto_po2"]
+
+      if self.alpha is None:
+        scale = self.default_alpha
+      elif isinstance(self.alpha, six.string_types):
+        scale = 1.0
+        assert self.alpha in ["auto", "auto_po2"]
+      else:
+        assert self.alpha >= 0.0
+        scale = float(self.alpha)
+
       len_axis = len(x.shape)
       if len_axis > 1:
         if K.image_data_format() == "channels_last":
@@ -874,37 +780,59 @@ class stochastic_binary(object):  # pylint: disable=invalid-name
           axis = list(range(1, len_axis))
       else:
         axis = [0]
-      std = K.std(x, axis=axis, keepdims=True) + K.epsilon()
-    else:
-      std = 1.0
 
-    if self.use_real_sigmoid:
-      p = tf.keras.backend.sigmoid(self.temperature * x / std)
-    else:
-      p = _sigmoid(self.temperature * x / std)
+      x_std = K.std(x, axis=axis, keepdims=True)
 
-    r = tf.random.uniform(tf.shape(x))
-    q = tf.sign(p - r)
-    q += (1.0 - tf.abs(q))
-    q_non_stochastic = tf.sign(x)
-    q_non_stochastic += (1.0 - tf.abs(q_non_stochastic))
-    scale = _get_scale(self.alpha, x, q_non_stochastic)
-    self.scale = scale
-    return x + tf.stop_gradient(-x + scale * q)
+      m = K.max(tf.abs(x), axis=axis, keepdims=True)
+      scale = 2.*m/3.
+      if self.alpha == "auto_po2":
+        scale = K.pow(2.0,
+                      tf.math.round(K.log(scale + K.epsilon()) / np.log(2.0)))
+      for _ in range(self.number_of_unrolls):
+        T = scale / 2.0
+        q_ns = K.cast(tf.abs(x) >= T, K.floatx()) * K.sign(x)
+        scale = _get_scale(self.alpha, x, q_ns)
+
+      x_norm = x / (x_std + K.epsilon())
+      T = scale / (2.0 * (x_std + K.epsilon()))
+
+      if self.use_real_sigmoid:
+        p0 = tf.keras.backend.sigmoid(self.temperature * (x_norm - T))
+        p1 = tf.keras.backend.sigmoid(self.temperature * (x_norm + T))
+      else:
+        p0 = _sigmoid(self.temperature * (x_norm - T))
+        p1 = _sigmoid(self.temperature * (x_norm + T))
+      r0 = tf.random.uniform(tf.shape(p0))
+      r1 = tf.random.uniform(tf.shape(p1))
+      q0 = tf.sign(p0 - r0)
+      q0 += (1.0 - tf.abs(q0))
+      q1 = tf.sign(p1 - r1)
+      q1 += (1.0 - tf.abs(q1))
+
+      q = (q0 + q1) / 2.0
+      self.scale = scale
+      return x + tf.stop_gradient(-x + scale * q)
+    
+    output = tf_utils.smart_cond(K.learning_phase(), 
+                                 stochastic_output,
+                                 lambda: ternary.__call__(self, x))
+    return output
 
   def _set_trainable_parameter(self):
     if self.alpha is None:
       self.alpha = "auto_po2"
+      if self.threshold is None:
+        self.threshold = self.default_threshold
 
   def max(self):
-    """Get the maximum value that stochastic_binary can respresent."""
+    """Get the maximum value that stochastic_ternary can respresent."""
     if self.alpha is None or isinstance(self.alpha, six.string_types):
       return 1.0
     else:
       return max(1.0, self.alpha)
 
   def min(self):
-    """Get the minimum value that stochastic_binary can respresent."""
+    """Get the minimum value that stochastic_ternary can respresent."""
     if self.alpha is None or isinstance(self.alpha, six.string_types):
       return -1.0
     else:
@@ -917,13 +845,15 @@ class stochastic_binary(object):  # pylint: disable=invalid-name
   def get_config(self):
     config = {
         "alpha": self.alpha,
+        "threshold": self.threshold,
         "temperature": self.temperature,
         "use_real_sigmoid": self.use_real_sigmoid,
+        "number_of_unrolls": self.number_of_unrolls
     }
     return config
 
 
-class binary(object):  # pylint: disable=invalid-name
+class binary(BaseQuantizer):  # pylint: disable=invalid-name
   """Computes the sign(x) returning a value between -alpha and alpha.
 
   Although we cannot guarantee E[dL/dy] = E[dL/dx] if we do not use the
@@ -944,6 +874,7 @@ class binary(object):  # pylint: disable=invalid-name
   """
 
   def __init__(self, use_01=False, alpha=None, use_stochastic_rounding=False):
+    super(binary, self).__init__()
     self.use_01 = use_01
     self.bits = 1
     self.alpha = alpha
@@ -994,19 +925,27 @@ class binary(object):  # pylint: disable=invalid-name
       m = tf.where(m > 1.0, tf.ones_like(m), m)
       f = 2 * m
 
-      x = f * _round_through(
-          x / f, use_stochastic_rounding=self.use_stochastic_rounding,
-          precision=0.125
-      )
+      x = tf_utils.smart_cond(
+          K.learning_phase(),
+          lambda: f * _round_through(
+              x / f, use_stochastic_rounding=True, precision=0.125),
+          lambda: x)
 
     k_sign = tf.sign(x)
     if self.use_stochastic_rounding:
-      k_sign += (1.0 - tf.abs(k_sign)) * (
-          2.0 * tf.round(tf.random.uniform(tf.shape(x))) - 1.0)
+      # in inference, we use a biased "1" for stochastic rounding right now
+      k_sign += (1.0 - tf.abs(k_sign)) * tf_utils.smart_cond(
+          K.learning_phase(),
+          lambda: 2.0 * tf.round(tf.random.uniform(tf.shape(x))) - 1.0,
+          lambda: tf.ones_like(tf.shape(x), dtype=K.floatx()))
       # if something still remains, just make it positive for now.
     k_sign += (1.0 - tf.abs(k_sign))
     if self.use_01:
       k_sign = (k_sign + 1.0) / 2.0
+
+    # approximate binary by tanh(x) as it has limited range between -1 and +1.
+    if self.alpha is None:
+      x = K.tanh(x)
 
     scale = _get_scale(self.alpha, x, k_sign)
     self.scale = scale
@@ -1045,7 +984,113 @@ class binary(object):  # pylint: disable=invalid-name
     return config
 
 
-class quantized_relu(object):  # pylint: disable=invalid-name
+class stochastic_binary(binary):  # pylint: disable=invalid-name
+  """Computes a stochastic activation function returning -alpha or +alpha.
+
+  Computes straight-through approximation using random sampling to make
+  E[dL/dy] = E[dL/dx], and computing the sign function. See explanation above.
+
+  Attributes:
+    x: tensor to perform sign opertion with stochastic sampling.
+    alpha: binary is -alpha or +alpha, or "auto" or "auto_po2".
+    bits: number of bits to perform quantization.
+    temperature: amplifier factor for sigmoid function, making stochastic
+        behavior less stochastic as it moves away from 0.
+    use_real_sigmoid: use real sigmoid from tensorflow for probablity.
+
+  Returns:
+    Computation of sign with stochastic sampling with straight through gradient.
+  """
+
+  def __init__(self, alpha=None, temperature=6.0, use_real_sigmoid=True):
+    super(stochastic_binary, self).__init__(alpha=alpha)
+    self.alpha = alpha
+    self.bits = 1
+    self.temperature = temperature
+    self.use_real_sigmoid = use_real_sigmoid
+    self.default_alpha = 1.0
+    self.scale = None
+
+  def __str__(self):
+    flags = []
+    if self.alpha is not None:
+      alpha = str(self.alpha)
+      if isinstance(self.alpha, six.string_types):
+        alpha = "'" + alpha + "'"
+      flags.append("alpha=" + alpha)
+    if self.temperature != 6.0:
+      flags.append("temperature=" + str(self.temperature))
+    if not self.use_real_sigmoid:
+      flags.append("use_real_sigmoid=" + str(int(self.use_real_sigmoid)))
+    return "stochastic_binary(" + ",".join(flags) + ")"
+
+  def __call__(self, x):
+    def stochastic_output():
+      if isinstance(self.alpha, six.string_types):
+        assert self.alpha in ["auto", "auto_po2"]
+        len_axis = len(x.shape)
+        if len_axis > 1:
+          if K.image_data_format() == "channels_last":
+            axis = list(range(len_axis - 1))
+          else:
+            axis = list(range(1, len_axis))
+        else:
+          axis = [0]
+        std = K.std(x, axis=axis, keepdims=True) + K.epsilon()
+      else:
+        std = 1.0
+
+      if self.use_real_sigmoid:
+        p = tf.keras.backend.sigmoid(self.temperature * x / std)
+      else:
+        p = _sigmoid(self.temperature * x / std)
+
+      r = tf.random.uniform(tf.shape(x))
+      q = tf.sign(p - r)
+      q += (1.0 - tf.abs(q))
+      q_non_stochastic = tf.sign(x)
+      q_non_stochastic += (1.0 - tf.abs(q_non_stochastic))
+      scale = _get_scale(self.alpha, x, q_non_stochastic)
+      self.scale = scale
+      return x + tf.stop_gradient(-x + scale * q)
+    
+    output = tf_utils.smart_cond(K.learning_phase(),
+                                 stochastic_output,
+                                 lambda: binary.__call__(self, x))
+    return output
+
+  def _set_trainable_parameter(self):
+    if self.alpha is None:
+      self.alpha = "auto_po2"
+
+  def max(self):
+    """Get the maximum value that stochastic_binary can respresent."""
+    if self.alpha is None or isinstance(self.alpha, six.string_types):
+      return 1.0
+    else:
+      return max(1.0, self.alpha)
+
+  def min(self):
+    """Get the minimum value that stochastic_binary can respresent."""
+    if self.alpha is None or isinstance(self.alpha, six.string_types):
+      return -1.0
+    else:
+      return -max(1.0, self.alpha)
+
+  @classmethod
+  def from_config(cls, config):
+    return cls(**config)
+
+  def get_config(self):
+    config = {
+        "alpha": self.alpha,
+        "temperature": self.temperature,
+        "use_real_sigmoid": self.use_real_sigmoid,
+    }
+    return config
+
+
+class quantized_relu(BaseQuantizer):  # pylint: disable=invalid-name
   """Computes a quantized relu to a number of bits.
 
   Modified from:
@@ -1076,6 +1121,7 @@ class quantized_relu(object):  # pylint: disable=invalid-name
 
   def __init__(self, bits=8, integer=0, use_sigmoid=0,
                use_stochastic_rounding=False):
+    super(quantized_relu, self).__init__()
     self.bits = bits
     self.integer = integer
     self.use_sigmoid = use_sigmoid
@@ -1136,7 +1182,7 @@ class quantized_relu(object):  # pylint: disable=invalid-name
     return config
 
 
-class quantized_ulaw(object):  # pylint: disable=invalid-name
+class quantized_ulaw(BaseQuantizer):  # pylint: disable=invalid-name
   """Computes a u-law quantization.
 
   Attributes:
@@ -1151,6 +1197,7 @@ class quantized_ulaw(object):  # pylint: disable=invalid-name
   """
 
   def __init__(self, bits=8, integer=0, symmetric=0, u=255.0):
+    super(quantized_ulaw, self).__init__()
     self.bits = bits
     self.integer = integer
     self.symmetric = symmetric
@@ -1211,7 +1258,7 @@ class quantized_ulaw(object):  # pylint: disable=invalid-name
     return config
 
 
-class quantized_tanh(object):  # pylint: disable=invalid-name
+class quantized_tanh(BaseQuantizer):  # pylint: disable=invalid-name
   """Computes a quantized tanh to a number of bits.
 
   Modified from:
@@ -1250,9 +1297,8 @@ class quantized_tanh(object):  # pylint: disable=invalid-name
     m_i = pow(2, self.integer)
     p = _sigmoid(x / m_i) * m
     xq = m_i * tf.keras.backend.clip(
-        2.0 *
-        (_round_through(p, self.use_stochastic_rounding) / m) - 1.0, -1.0 +
-        (1.0 * self.symmetric) / m, 1.0 - 1.0 / m)
+        2.0 * (_round_through(p, self.use_stochastic_rounding) / m) - \
+        1.0, -1.0 + (1.0 * self.symmetric) / m, 1.0 - 1.0 / m)
     return xq
 
   def _set_trainable_parameter(self):
@@ -1330,16 +1376,22 @@ def _clip_power_of_two(x_abs,
       q_factor = 2.0
     else:
       q_factor = 1.0
+
     if use_stochastic_rounding:
       if quadratic_approximation:
-        x_log2 = stochastic_round_po2(tf.sqrt(x_abs))
+        x_log2 = tf_utils.smart_cond(K.learning_phase(),
+            lambda: stochastic_round_po2(tf.sqrt(x_abs)),
+            lambda: _round_through(tf.keras.backend.log(tf.sqrt(x_abs)) / log2))
       else:
-        x_log2 = stochastic_round_po2(x_abs)
+        x_log2 = tf_utils.smart_cond(K.learning_phase(),
+            lambda: stochastic_round_po2(x_abs),
+            lambda: _round_through(tf.keras.backend.log(x_abs) / log2))
     else:
       if quadratic_approximation:
         x_log2 = _round_through(tf.keras.backend.log(tf.sqrt(x_abs)) / log2)
       else:
         x_log2 = _round_through(tf.keras.backend.log(x_abs) / log2)
+
     x_clipped = q_factor * tf.keras.backend.clip(x_log2, min_exp, max_exp)
     return x_clipped
 
@@ -1403,7 +1455,7 @@ def _get_min_max_exponents(non_sign_bits, need_exponent_sign_bit,
   return min_exp, max_exp
 
 
-class quantized_po2(object):  # pylint: disable=invalid-name
+class quantized_po2(BaseQuantizer):  # pylint: disable=invalid-name
   """Quantizes to the closest power of 2.
 
   Attributes:
@@ -1448,10 +1500,9 @@ class quantized_po2(object):  # pylint: disable=invalid-name
     x_sign = tf.sign(x)
     x_sign += (1.0 - tf.abs(x_sign))
     x_abs = tf.abs(x)
-    x_clipped = _clip_power_of_two(x_abs, self._min_exp, self._max_exp,
-                                   self.max_value,
-                                   self.quadratic_approximation,
-                                   self.use_stochastic_rounding)
+    x_clipped = _clip_power_of_two(
+        x_abs, self._min_exp, self._max_exp, self.max_value,
+        self.quadratic_approximation, self.use_stochastic_rounding)
     return x + tf.stop_gradient(-x + x_sign * pow(2.0, x_clipped))
 
   def _set_trainable_parameter(self):
@@ -1497,7 +1548,7 @@ class quantized_po2(object):  # pylint: disable=invalid-name
     return config
 
 
-class quantized_relu_po2(object):  # pylint: disable=invalid-name
+class quantized_relu_po2(BaseQuantizer):  # pylint: disable=invalid-name
   """Quantizes x to the closest power of 2 when x > 0 else 2**min_exp.
 
   Attributes:
@@ -1545,10 +1596,9 @@ class quantized_relu_po2(object):  # pylint: disable=invalid-name
       x = tf.where(
           x <= self.max_value, K.relu(x), tf.ones_like(x) * self.max_value)
 
-    x_clipped = _clip_power_of_two(x, self._min_exp, self._max_exp,
-                                   self.max_value,
-                                   self.quadratic_approximation,
-                                   self.use_stochastic_rounding)
+    x_clipped = _clip_power_of_two(
+        x, self._min_exp, self._max_exp, self.max_value,
+        self.quadratic_approximation, self.use_stochastic_rounding)
     return x + tf.stop_gradient(-x + pow(2.0, x_clipped))
 
   def _set_trainable_parameter(self):

--- a/qkeras/quantizers.py
+++ b/qkeras/quantizers.py
@@ -219,9 +219,10 @@ def _round_through(x, use_stochastic_rounding=False, precision=0.5):
     Rounded tensor.
   """
   if use_stochastic_rounding:
-    output = tf_utils.smart_cond(K.learning_phase(),
-    lambda: x + tf.stop_gradient(-x + stochastic_round(x, precision)),
-    lambda: x + tf.stop_gradient(-x + tf.round(x)))
+    output = tf_utils.smart_cond(
+      K.learning_phase(),
+      lambda: x + tf.stop_gradient(-x + stochastic_round(x, precision)),
+      lambda: x + tf.stop_gradient(-x + tf.round(x)))
   else:
     output = x + tf.stop_gradient(-x + tf.round(x))
   return output
@@ -811,9 +812,10 @@ class stochastic_ternary(ternary):  # pylint: disable=invalid-name
       self.scale = scale
       return x + tf.stop_gradient(-x + scale * q)
     
-    output = tf_utils.smart_cond(K.learning_phase(), 
-                                 stochastic_output,
-                                 lambda: ternary.__call__(self, x))
+    output = tf_utils.smart_cond(
+      K.learning_phase(), 
+      stochastic_output,
+      lambda: ternary.__call__(self, x))
     return output
 
   def _set_trainable_parameter(self):
@@ -1378,13 +1380,15 @@ def _clip_power_of_two(x_abs,
 
     if use_stochastic_rounding:
       if quadratic_approximation:
-        x_log2 = tf_utils.smart_cond(K.learning_phase(),
-            lambda: stochastic_round_po2(tf.sqrt(x_abs)),
-            lambda: _round_through(tf.keras.backend.log(tf.sqrt(x_abs)) / log2))
+        x_log2 = tf_utils.smart_cond(
+          K.learning_phase(),
+          lambda: stochastic_round_po2(tf.sqrt(x_abs)),
+          lambda: _round_through(tf.keras.backend.log(tf.sqrt(x_abs)) / log2))
       else:
-        x_log2 = tf_utils.smart_cond(K.learning_phase(),
-            lambda: stochastic_round_po2(x_abs),
-            lambda: _round_through(tf.keras.backend.log(x_abs) / log2))
+        x_log2 = tf_utils.smart_cond(
+          K.learning_phase(),
+          lambda: stochastic_round_po2(x_abs),
+          lambda: _round_through(tf.keras.backend.log(x_abs) / log2))
     else:
       if quadratic_approximation:
         x_log2 = _round_through(tf.keras.backend.log(tf.sqrt(x_abs)) / log2)

--- a/tests/qactivation_test.py
+++ b/tests/qactivation_test.py
@@ -363,9 +363,11 @@ def test_binary(use_01, alpha, test_values, expected_values):
     (np.array([[0.0] * 100000], dtype=K.floatx()), 0.0),
 ])
 def test_stochastic_round_quantized_po2(test_values, expected_values):
+  K.set_learning_phase(1)
   np.random.seed(666)
-  x = K.placeholder(ndim=2)
-  f = K.function([x], [quantized_po2(use_stochastic_rounding=True)(x)])
+  x = K.placeholder(ndim=2) 
+  q = quantized_po2(use_stochastic_rounding=True)
+  f = K.function([x], [q(x)])
   res = f([test_values])[0]
   res = np.average(res)
   assert_allclose(res, expected_values, rtol=1e-01, atol=1e-6)
@@ -379,9 +381,11 @@ def test_stochastic_round_quantized_po2(test_values, expected_values):
     (np.array([[48.0] * 100000], dtype=K.floatx()), 48.0),
 ])
 def test_stochastic_round_quantized_relu_po2(test_values, expected_values):
+  K.set_learning_phase(1)
   np.random.seed(666)
   x = K.placeholder(ndim=2)
-  f = K.function([x], [quantized_relu_po2(use_stochastic_rounding=True)(x)])
+  q = quantized_relu_po2(use_stochastic_rounding=True)
+  f = K.function([x], [q(x)])
   res = f([test_values])[0]
   res = np.average(res)
   assert_allclose(res, expected_values, rtol=1e-01, atol=1e-6)
@@ -389,11 +393,13 @@ def test_stochastic_round_quantized_relu_po2(test_values, expected_values):
 
 def test_stochastic_binary():
   np.random.seed(42)
+  K.set_learning_phase(1)
 
   x = np.random.uniform(-0.01, 0.01, size=10)
   x = np.sort(x)
 
   s = stochastic_binary(alpha="auto_po2")
+
   ty = np.zeros_like(s)
   ts = 0.0
 
@@ -417,50 +423,86 @@ def test_stochastic_binary():
   assert_allclose(scale, expected_scale, rtol=0.1)
 
 
+@pytest.mark.parametrize('alpha, test_values, expected_values', [
+    (1.0,
+     np.array([[-3.0, -2.0, -1.0, -0.2, 0.0, 0.3, 1, 4, 10]], dtype=K.floatx()),
+     np.array([[-1.0, -1.0, -1.0, -1.0, 1, 1, 1, 1, 1]], dtype=K.floatx())),
+    (5.0,
+     np.array([[-11.0, -7.0, -4.0, -0.2, 0.0, 0.3, 1, 4, 10]],
+              dtype=K.floatx()),
+     np.array([[-5.0, -5.0, -5.0, -5, 5.0, 5.0, 5, 5, 5]], dtype=K.floatx()))
+])
+def test_stochastic_binary_inference_mode(alpha, test_values, expected_values):
+  K.set_learning_phase(0)
+  x = K.placeholder(ndim=2)
+  q = stochastic_binary(alpha)
+  f = K.function([x], [q(x)])
+  result = f([test_values])[0]
+  assert_allclose(result, expected_values, rtol=1e-05)
+
+
 @pytest.mark.parametrize(
-    'bound, alpha, temperature, expected_values, expected_scale',
-    [(0.5, None, 8,
-      np.array([-0.254, -0.028, -0.025, 0., 0., 0., 0.001, 0., 0.02, 0.141
-               ]).astype(np.float32), np.array([1.0])),
-     (0.01, 0.0033, 8,
-      np.array([-1., -0.999, -0.999, -0.735, 0.605, 0.62, 0.972, 0.981, 1., 1.
-               ]).astype(np.float32), np.array([0.0033])),
-     (3, 5.0, 8,
-      np.array([-0.682, -0.135, -0.132, 0., 0., 0., 0.002, 0.003, 0.194, 0.709
-               ]).astype(np.float32), np.array([5.0])),
-     (0.01, 'auto', 8,
-      np.array([
-          -0.999, -0.987, -0.992, -0.219, 0.114, 0.114, 0.697, 0.828, 0.991, 1.
-      ]).astype(np.float32), np.array([0.0068196])),
-     (0.01, 'auto_po2', 8,
-      np.array([
-          -0.998, -0.986, -0.977, -0.127, 0.057, 0.088, 0.631, 0.709, 0.986,
-          0.999
-      ]).astype(np.float32), np.array([0.007812]))])
-def test_stochastic_ternary(bound, alpha, temperature, expected_values,
-                            expected_scale):
+    'bound, alpha, temperature, expected_values, expected_scale', [
+    (
+        0.01,
+        "auto",
+        8,
+        np.array([-0.973, -0.903, -0.759, -0.574, -0.242,  0.161,  0.508,  0.723,
+            0.874,  0.975]).astype(np.float32),
+        np.array([0.008427, 0.007001, 0.0057  , 0.004457, 0.003537, 0.003416,
+            0.004507, 0.005536, 0.006853, 0.008282]).astype(np.float32)
+    ),
+    (
+        0.01,
+        "auto_po2",
+        8, 
+        np.array([-0.979, -0.877, -0.639, -0.586, -0.23 ,  0.154,  0.327,  0.603,
+            0.83 ,  0.986]).astype(np.float32),
+        np.array([0.007812, 0.007812, 0.007812, 0.003906, 0.003906, 0.003906,
+            0.007812, 0.007812, 0.007812, 0.007812]).astype(np.float32)
+    )
+])
+def test_stochastic_ternary(bound, alpha, temperature, expected_values, expected_scale):
   np.random.seed(42)
-
-  x = np.random.uniform(-bound, bound, size=10)
-  x = np.sort(x)
-
-  s = stochastic_ternary(alpha=alpha, temperature=temperature)
-  ty = np.zeros_like(s)
-  ts = 0.0
+  K.set_learning_phase(1)
 
   n = 1000
 
-  for _ in range(n):
-    y = K.eval(s(K.constant(x)))
-    scale = float(K.eval(s.scale))
-    ts = ts + scale
-    ty = ty + (y / scale)
+  x = np.random.uniform(-bound, bound, size=(n, 10))
+  x = np.sort(x, axis=1)
+
+  s = stochastic_ternary(alpha=alpha, temperature=temperature)
+
+  y = K.eval(s(K.constant(x)))
+  scale = K.eval(s.scale).astype(np.float32)[0]
+
+  ty = np.zeros_like(s)
+  for i in range(n):
+    ty = ty + (y[i] / scale)
 
   result = (ty/n).astype(np.float32)
-  scale = np.array([ts/n])
 
   assert_allclose(result, expected_values, atol=0.1)
   assert_allclose(scale, expected_scale, rtol=0.1)
+
+
+@pytest.mark.parametrize('alpha, threshold, test_values, expected_values', [
+    (1.0, 0.33,
+     np.array([[-3.0, -2.0, -1.0, -0.2, 0.0, 0.3, 1, 4, 10]], dtype=K.floatx()),
+     np.array([[-1.0, -1.0, -1.0, 0, 0.0, 0.0, 1, 1, 1]], dtype=K.floatx())),
+    (10.0, 5.0,
+     np.array([[-11.0, -7.0, -4.0, -0.2, 0.0, 0.3, 1, 4, 10]],
+              dtype=K.floatx()),
+     np.array([[-10.0, -10.0, 0.0, 0, 0.0, 0.0, 0, 0, 10]], dtype=K.floatx())),
+])
+def test_stochastic_ternary_inference_mode(alpha, threshold, test_values, expected_values):
+  K.set_learning_phase(0)
+  x = K.placeholder(ndim=2)
+  q = stochastic_ternary(alpha, threshold)
+  f = K.function([x],
+                 [q(x)])
+  result = f([test_values])[0]
+  assert_allclose(result, expected_values, rtol=1e-05)
 
 
 if __name__ == '__main__':

--- a/tests/qconvolutional_test.py
+++ b/tests/qconvolutional_test.py
@@ -51,6 +51,7 @@ from qkeras import extract_model_operations
 #   qbatchnorm test
 
 def test_qnetwork():
+  K.set_learning_phase(1)
   x = x_in = Input((28, 28, 1), name='input')
   x = QSeparableConv2D(
       32, (2, 2),


### PR DESCRIPTION
Currently, quantizers peform stochastic operations even in inference mode (K.learning_phase() = 0). This mechanism prevents this and uses the non-stochastic version of the quantizer if in inference mode.

Added
- base_quantizer class with is_training attribute and setter method
- unit tests for stochastic quantizers inference mode behavior

Modified:
- stochastic_{ternary, binary} now inherit from their non stochastic counterparts to delegate inference mode computaiton
- Order of quantizer definition to perfom inheritance
- Used the super invokation method in quantizers instead of referring to the base class explicitly
- set the proper learning_phase in qactivation_test, qconvolutional_test
- Fixed _round_through and _clip_power_of_two and their references by using smart_cond to disable stochastic behavior

Some fixes by Claudionor:
- Fixed multiple instance of tensorflow conditionals in quantizers.py
- Changed stochastic_ternary test to remove the 0 variance cases