### PR TITLE
Transposed convolution (deconvolution)

### DIFF
--- a/examples/example_mnist.py
+++ b/examples/example_mnist.py
@@ -63,8 +63,8 @@ x_test = x_test.astype("float32")
 x_train = x_train[..., np.newaxis]
 x_test = x_test[..., np.newaxis]
 
-x_train /= 255.0
-x_test /= 255.0
+x_train /= 256.0
+x_test /= 256.0
 
 print(x_train.shape[0], "train samples")
 print(x_test.shape[0], "test samples")

--- a/examples/example_mnist_ae.py
+++ b/examples/example_mnist_ae.py
@@ -61,8 +61,8 @@ x_test = x_test.astype("float32")
 x_train = x_train[..., np.newaxis]
 x_test = x_test[..., np.newaxis]
 
-x_train /= 255.0
-x_test /= 255.0
+x_train /= 256.0
+x_test /= 256.0
 
 print(x_train.shape[0], "train samples")
 print(x_test.shape[0], "test samples")

--- a/examples/example_mnist_ae.py
+++ b/examples/example_mnist_ae.py
@@ -1,0 +1,147 @@
+# Copyright 2019 Google LLC
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""uses po2."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+from collections import defaultdict
+
+import tensorflow.keras.backend as K
+from tensorflow.keras.datasets import mnist
+from tensorflow.keras.layers import Activation
+from tensorflow.keras.layers import Flatten
+from tensorflow.keras.layers import Input
+from tensorflow.keras.layers import *
+from tensorflow.keras.models import Model
+from tensorflow.keras.optimizers import Adam
+from tensorflow.keras.optimizers import SGD
+from tensorflow.keras.utils import to_categorical
+
+from qkeras import *
+from qkeras.utils import model_save_quantized_weights
+
+
+import numpy as np
+import tensorflow.compat.v1 as tf
+
+np.random.seed(42)
+
+NB_EPOCH = 100
+BATCH_SIZE = 64
+VERBOSE = 1
+NB_CLASSES = 10
+OPTIMIZER = Adam(lr=0.0001, decay=0.000025)
+VALIDATION_SPLIT = 0.1
+
+train = 1
+
+(x_train, y_train), (x_test, y_test) = mnist.load_data()
+
+RESHAPED = 784
+
+x_train = x_train.astype("float32")
+x_test = x_test.astype("float32")
+
+x_train = x_train[..., np.newaxis]
+x_test = x_test[..., np.newaxis]
+
+x_train /= 255.0
+x_test /= 255.0
+
+print(x_train.shape[0], "train samples")
+print(x_test.shape[0], "test samples")
+
+print(y_train[0:10])
+
+y_train = to_categorical(y_train, NB_CLASSES)
+y_test = to_categorical(y_test, NB_CLASSES)
+
+x = x_in = Input(
+    x_train.shape[1:-1] + (1,))
+x = QConv2D(
+    32,
+    kernel_size=(3, 3),
+    kernel_quantizer=quantized_bits(4,0,1),
+    bias_quantizer=quantized_bits(4,0,1))(x)
+x = QActivation("quantized_relu(4,0)")(x)
+x = QConv2D(
+    16,
+    kernel_size=(3, 3),
+    kernel_quantizer=quantized_bits(4,0,1),
+    bias_quantizer=quantized_bits(4,0,1))(x)
+x = QActivation("quantized_relu(4,0)")(x)
+x = QConv2D(
+    8,
+    kernel_size=(3, 3),
+    kernel_quantizer=quantized_bits(4,0,1),
+    bias_quantizer=quantized_bits(4,0,1))(x)
+x = QActivation("quantized_relu(4,0)")(x)
+x = QConv2DTranspose(
+    8,
+    kernel_size=(3, 3),
+    kernel_quantizer=quantized_bits(4,0,1),
+    bias_quantizer=quantized_bits(4,0,1))(x)
+x = QActivation("quantized_relu(4,0)")(x)
+x = QConv2DTranspose(
+    16,
+    kernel_size=(3, 3),
+    kernel_quantizer=quantized_bits(4,0,1),
+    bias_quantizer=quantized_bits(4,0,1))(x)
+x = QActivation("quantized_relu(4,0)")(x)
+x = QConv2DTranspose(
+    32,
+    kernel_size=(3, 3),
+    kernel_quantizer=quantized_bits(4,0,1),
+    bias_quantizer=quantized_bits(4,0,1))(x)
+x = QActivation("quantized_relu(4,0)")(x)
+x = QConv2D(
+    1,
+    kernel_size=(3, 3),
+    padding="same",
+    kernel_quantizer=quantized_bits(4,0,1),
+    bias_quantizer=quantized_bits(4,0,1))(x)
+x_out = x
+x = Activation("sigmoid")(x)
+
+model = Model(inputs=[x_in], outputs=[x])
+mo = Model(inputs=[x_in], outputs=[x_out])
+model.summary()
+
+model.compile(
+    loss="binary_crossentropy", optimizer=OPTIMIZER, metrics=["accuracy"])
+
+if train:
+
+  history = model.fit(
+      x_train, x_train, batch_size=BATCH_SIZE,
+      epochs=NB_EPOCH, initial_epoch=1, verbose=VERBOSE,
+      validation_split=VALIDATION_SPLIT)
+
+  # Generate reconstructions
+  num_reco = 8
+  samples = x_test[:num_reco]
+  targets = y_test[:num_reco]
+  reconstructions = model.predict(samples)
+
+
+for layer in model.layers:
+  for w, weight in enumerate(layer.get_weights()):
+    print(layer.name, w, weight.shape)
+
+print_qstats(model)

--- a/examples/example_mnist_b2t.py
+++ b/examples/example_mnist_b2t.py
@@ -59,8 +59,8 @@ x_train = x_train[..., np.newaxis]
 x_test = x_test[..., np.newaxis]
 
 if T_CLASSES == 1:
-  x_train /= 255.0
-  x_test /= 255.0
+  x_train /= 256.0
+  x_test /= 256.0
 
 print(x_train.shape[0], "train samples")
 print(x_test.shape[0], "test samples")

--- a/examples/example_mnist_bn.py
+++ b/examples/example_mnist_bn.py
@@ -82,8 +82,8 @@ lra = LearningRateAdjuster()
 x_train = x_train.reshape(x_train.shape + (1,)).astype("float32")
 x_test = x_test.reshape(x_test.shape + (1,)).astype("float32")
 
-x_train /= 255.0
-x_test /= 255.0
+x_train /= 256.0
+x_test /= 256.0
 
 print(x_train.shape[0], "train samples")
 print(x_test.shape[0], "test samples")

--- a/examples/example_mnist_po2.py
+++ b/examples/example_mnist_po2.py
@@ -54,8 +54,8 @@ x_test = x_test.astype("float32")
 x_train = x_train[..., np.newaxis]
 x_test = x_test[..., np.newaxis]
 
-x_train /= 255.0
-x_test /= 255.0
+x_train /= 256.0
+x_test /= 256.0
 
 train = False
 

--- a/qkeras/autoqkeras/autoqkeras_internal.py
+++ b/qkeras/autoqkeras/autoqkeras_internal.py
@@ -186,11 +186,6 @@ class AutoQKHyperModel(HyperModel):
         elif length < 3:
           # No recurrent limit needed for non recurrent layers
           self.limit[name] = self.limit[name] + default[length:2] + default[-1:]
-    
-    if 'Activation' in self.limit:
-      assert len(self.limit['Activation']) == 1
-    else:
-      self.limit['Activation'] = default[-1]
 
   def _n(self, name, s_list):
     """Creates a unique name for the tuner."""

--- a/qkeras/autoqkeras/autoqkeras_internal.py
+++ b/qkeras/autoqkeras/autoqkeras_internal.py
@@ -71,7 +71,8 @@ from qkeras.utils import model_quantize
 #
 
 REGISTERED_LAYERS = ["Dense", "Conv1D", "Conv2D", "DepthwiseConv2D",
-                     "SimpleRNN", "LSTM", "GRU", "Bidirectional"]
+                     "SimpleRNN", "LSTM", "GRU", "Bidirectional",
+                     "Conv2DTranspose"]
 
 Q_LAYERS = list(map(lambda x : 'Q' + x, REGISTERED_LAYERS))
 
@@ -352,7 +353,8 @@ class AutoQKHyperModel(HyperModel):
               not filter_sweep_enabled and self.tune_filters in
               ["layer", "block"]
               and not self.tune_filters_exceptions.search(layer.name) and
-              layer.__class__.__name__ in ["Dense", "Conv1D", "Conv2D"]
+              layer.__class__.__name__ in
+              ["Dense", "Conv1D", "Conv2D", "Conv2DTranspose"]
           ):
             filter_sweep_enabled = True
 
@@ -415,7 +417,7 @@ class AutoQKHyperModel(HyperModel):
         if (
             self.tune_filters in ["layer", "block"] and
             not self.tune_filters_exceptions.search(layer.name) and
-            layer.__class__.__name__ in ["Dense", "Conv1D", "Conv2D"]
+            layer.__class__.__name__ in ["Dense", "Conv1D", "Conv2D", "Conv2DTranspose"]
         ):
           if self.tune_filters == "layer":
             layer_filters = hp.Choice(
@@ -428,7 +430,7 @@ class AutoQKHyperModel(HyperModel):
 
           if layer.__class__.__name__ == "Dense":
             layer.units = max(int(layer.units * layer_filters), 1)
-          elif layer.__class__.__name__ in ["Conv1D", "Conv2D"]:
+          elif layer.__class__.__name__ in ["Conv1D", "Conv2D", "Conv2DTranspose"]:
             layer.filters = max(int(layer.filters * layer_filters), 1)
 
         layer_d[kernel_name] = kernel_quantizer

--- a/qkeras/utils.py
+++ b/qkeras/utils.py
@@ -685,7 +685,8 @@ def get_model_sparsity(model, per_layer=False, allow_list=None):
     allow_list = [
         "QDense", "Dense", "QConv1D", "Conv1D", "QConv2D", "Conv2D",
         "QDepthwiseConv2D", "DepthwiseConv2D", "QSeparableConv2D",
-        "SeparableConv2D", "QOctaveConv2D", "QSimpleRNN", "RNN", "QLSTM", "QGRU",
+        "SeparableConv2D", "QOctaveConv2D", 
+        "QSimpleRNN", "RNN", "QLSTM", "QGRU",
         "QConv2DTranspose", "Conv2DTranspose"
     ]
 

--- a/qkeras/utils.py
+++ b/qkeras/utils.py
@@ -334,36 +334,10 @@ def model_quantize(model,
   for layer in layers:
     layer_config = layer["config"]
 
-    # Dense becomes QDense
+    # Dense becomes QDense, Conv1D becomes QConv1D etc
     # Activation converts activation functions
 
-    if layer["class_name"] == "Dense":
-      # needs to add kernel/bias quantizers
-      kernel_quantizer = get_config(
-          quantizer_config, layer, "QDense", "kernel_quantizer")
-      bias_quantizer = get_config(
-          quantizer_config, layer, "QDense", "bias_quantizer")
-
-      # this is to avoid unwanted transformations
-      if kernel_quantizer is None:
-        continue
-
-      layer["class_name"] = "QDense"
-
-      layer_config["kernel_quantizer"] = kernel_quantizer
-      layer_config["bias_quantizer"] = bias_quantizer
-
-      # if activation is present, add activation here
-      quantizer = get_config(
-          quantizer_config, layer, "QDense", "activation_quantizer")
-
-      if quantizer:
-        layer_config["activation"] = quantizer
-        custom_objects[quantizer] = safe_eval(quantizer, globals())
-      else:
-        quantize_activation(layer_config, activation_bits)
-
-    elif layer["class_name"] in ["Conv1D", "Conv2D", "Conv2DTranspose"]:
+    if layer["class_name"] in ["Dense", "Conv1D", "Conv2D", "Conv2DTranspose"]:
       q_name = "Q" + layer["class_name"]
       # needs to add kernel/bias quantizers
       kernel_quantizer = get_config(

--- a/tests/qconvolutional_test.py
+++ b/tests/qconvolutional_test.py
@@ -36,6 +36,7 @@ from qkeras import QActivation
 from qkeras import QDense
 from qkeras import QConv1D
 from qkeras import QConv2D
+from qkeras import QConv2DTranspose
 from qkeras import QSeparableConv2D
 from qkeras import quantized_bits
 from qkeras import quantized_relu
@@ -217,6 +218,28 @@ def test_qconv1d():
                  [-2.652, -0.467]]]).astype(np.float16)
   assert np.all(p == y)
 
+def test_qconv2dtranspose():
+  x = Input((4, 4, 1,))
+  y = QConv2DTranspose(
+    1,
+    kernel_size=(3, 3),
+    kernel_quantizer=binary(),
+    bias_quantizer=binary(),
+    name='conv2d_tran')(x)
+  model = Model(inputs=x, outputs=y)
+  data = np.ones(shape=(1,4,4,1))
+  kernel = np.ones(shape=(3,3,1,1))
+  bias = np.ones(shape=(1,))
+  model.get_layer('conv2d_tran').set_weights([kernel, bias])
+  actual_output = model.predict(data).astype(np.float16)
+  expected_output = np.array(
+      [ [2., 3., 4., 4., 3., 2.],
+      [3., 5., 7., 7., 5., 3.],
+      [4., 7., 10., 10., 7., 4.],
+      [4., 7., 10., 10., 7., 4.],
+      [3., 5., 7., 7., 5., 3.],
+      [2., 3., 4., 4., 3., 2.] ]).reshape((1,6,6,1)).astype(np.float16)
+  assert_allclose(actual_output, expected_output, rtol=1e-4)
 
 if __name__ == '__main__':
   pytest.main([__file__])


### PR DESCRIPTION
This PR adds `QConv2DTranspose` which is useful in autoencoders. I can also add `QConv1DTranspose` but the equivalent Keras layer is only avaiable in nightly TF releases, not in stable channel yet.