### PR TITLE
QSeparableConv1D and 2D

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,14 @@ http://arxiv.org/abs/2006.10159
 
 - QDepthwiseConv2D
 
-- QSeparableConv1D
+- QSeparableConv1D (depthwise + pointwise convolution, without
+quantizing the activation values after the depthwise step)
 
-- QSeparableConv2D (depthwise + pointwise expanded, extended from
-MobileNet SeparableConv2D implementation)
+- QSeparableConv2D (depthwise + pointwise convolution, without
+quantizing the activation values after the depthwise step)
+
+- QMobileNetSeparableConv2D (extended from MobileNet SeparableConv2D
+implementation, quantizes the activation values after the depthwise step)
 
 - QConv2DTranspose
 

--- a/README.md
+++ b/README.md
@@ -75,8 +75,12 @@ http://arxiv.org/abs/2006.10159
 
 - QDepthwiseConv2D
 
+- QSeparableConv1D
+
 - QSeparableConv2D (depthwise + pointwise expanded, extended from
 MobileNet SeparableConv2D implementation)
+
+- QConv2DTranspose
 
 - QActivation
 

--- a/qkeras/autoqkeras/autoqkeras_internal.py
+++ b/qkeras/autoqkeras/autoqkeras_internal.py
@@ -72,7 +72,7 @@ from qkeras.utils import model_quantize
 
 REGISTERED_LAYERS = ["Dense", "Conv1D", "Conv2D", "DepthwiseConv2D",
                      "SimpleRNN", "LSTM", "GRU", "Bidirectional",
-                     "Conv2DTranspose"]
+                     "Conv2DTranspose", "SeparableConv1D", "SeparableConv2D"]
 
 Q_LAYERS = list(map(lambda x : 'Q' + x, REGISTERED_LAYERS))
 
@@ -221,6 +221,13 @@ class AutoQKHyperModel(HyperModel):
       index = 1
       q_list = list(bq.keys())
       q_dict = bq
+    elif "pointwise_kernel" in head: # limit is same as kernel
+      # pointwise kernel quantizers
+      field_name = "pointwise_kernel"
+      kq = self.quantization_config["pointwise_kernel"]
+      index = 2
+      q_list = list(kq.keys())
+      q_dict = kq
     elif "recurrent_kernel" in head: # limit is same as kernel
       # recurrent kernel quantizers
       field_name = "recurrent_kernel"
@@ -358,6 +365,11 @@ class AutoQKHyperModel(HyperModel):
             hp, layer.name + "_recurrent_kernel", layer.name, layer.__class__.__name__,
             is_kernel=True)
 
+        if layer.__class__.__name__ in ["SeparableConv1D", "SeparableConv2D"]:
+          pointwise_quantizer, _ = self._get_quantizer(
+            hp, layer.name + "_pointwise_kernel", layer.name, layer.__class__.__name__,
+            is_kernel=True)
+
     if self.tune_filters == "block" and filter_sweep_enabled:
       network_filters = hp.Choice(
           "network_filters",
@@ -391,7 +403,9 @@ class AutoQKHyperModel(HyperModel):
       if layer.__class__.__name__ in REGISTERED_LAYERS:
         # difference between depthwise and the rest is just the name
         # of the kernel.
-        if layer.__class__.__name__ == "DepthwiseConv2D":
+        if layer.__class__.__name__ in [
+            "DepthwiseConv2D", "SeparableConv1D", "SeparableConv2D"
+        ]:
           kernel_name = "depthwise_quantizer"
         else:
           kernel_name = "kernel_quantizer"
@@ -412,7 +426,10 @@ class AutoQKHyperModel(HyperModel):
         if (
             self.tune_filters in ["layer", "block"] and
             not self.tune_filters_exceptions.search(layer.name) and
-            layer.__class__.__name__ in ["Dense", "Conv1D", "Conv2D", "Conv2DTranspose"]
+            layer.__class__.__name__ in [
+                "Dense", "Conv1D", "Conv2D", "Conv2DTranspose",
+                "SeparableConv1D", "SeparableConv2D"
+            ]
         ):
           if self.tune_filters == "layer":
             layer_filters = hp.Choice(
@@ -425,13 +442,19 @@ class AutoQKHyperModel(HyperModel):
 
           if layer.__class__.__name__ == "Dense":
             layer.units = max(int(layer.units * layer_filters), 1)
-          elif layer.__class__.__name__ in ["Conv1D", "Conv2D", "Conv2DTranspose"]:
+          elif layer.__class__.__name__ in [
+              "Conv1D", "Conv2D", "Conv2DTranspose",
+              "SeparableConv1D", "SeparableConv2D"
+          ]:
             layer.filters = max(int(layer.filters * layer_filters), 1)
 
         layer_d[kernel_name] = kernel_quantizer
 
         if layer.__class__.__name__ in SEQUENCE_LAYERS:
           layer_d['recurrent_quantizer'] = recurrent_quantizer
+        
+        if layer.__class__.__name__ in ["SeparableConv1D", "SeparableConv2D"]:
+          layer_d['pointwise_quantizer'] = pointwise_quantizer
 
         if layer.__class__.__name__ in ["LSTM", "GRU", "Bidirectional"]:
           layer_d['recurrent_activation'], _  = self._get_quantizer(

--- a/tests/qconvolutional_test.py
+++ b/tests/qconvolutional_test.py
@@ -37,6 +37,7 @@ from qkeras import QDense
 from qkeras import QConv1D
 from qkeras import QConv2D
 from qkeras import QConv2DTranspose
+from qkeras import QSeparableConv1D
 from qkeras import QSeparableConv2D
 from qkeras import quantized_bits
 from qkeras import quantized_relu
@@ -59,7 +60,7 @@ def test_qnetwork():
       strides=(2, 2),
       depthwise_quantizer=binary(alpha=1.0),
       pointwise_quantizer=quantized_bits(4, 0, 1, alpha=1.0),
-      depthwise_activation=quantized_bits(6, 2, 1, alpha=1.0),
+      activation=quantized_bits(6, 2, 1, alpha=1.0),
       bias_quantizer=quantized_bits(4, 0, 1),
       name='conv2d_0_m')(
           x)
@@ -102,9 +103,10 @@ def test_qnetwork():
     all_weights = []
     for i, weights in enumerate(layer.get_weights()):
       input_size = np.prod(layer.input.shape.as_list()[1:])
-      if input_size is None:
-        input_size = 576 * 10  # to avoid learning sizes
+      if (len(layer.get_weights()) == 3 and i > 0): # pointwise kernel and bias
+        input_size = input_size // np.prod(layer.kernel_size)
       shape = weights.shape
+      print(shape)
       assert input_size > 0, 'input size for {} {}'.format(layer.name, i)
       # he normal initialization with a scale factor of 2.0
       all_weights.append(
@@ -136,19 +138,19 @@ def test_qnetwork():
       [[0.e+00, 0.e+00, 0.e+00, 0.e+00, 0.e+00,
         0.e+00, 1.e+00, 0.e+00, 0.e+00, 0.e+00],
       [0.e+00, 0.e+00, 0.e+00, 0.e+00, 0.e+00,
+       0.e+00, 1.e+00, 0.e+00, 0.e+00, 7.6e-06],
+      [0.e+00, 0.e+00, 0.e+00, 0.e+00, 0.e+00,
+       0.e+00, 0.e+00, 0.e+00, 0.e+00, 1.e+00],
+      [0.e+00, 0.e+00, 0.e+00, 0.e+00, 0.e+00,
        0.e+00, 1.e+00, 0.e+00, 0.e+00, 0.e+00],
       [0.e+00, 0.e+00, 0.e+00, 0.e+00, 0.e+00,
-       0.e+00, 0.e+00, 0.e+00, 6.e-08, 1.e+00],
-      [0.e+00, 0.e+00, 0.e+00, 0.e+00, 0.e+00,
-       0.e+00, 1.e+00, 0.e+00, 0.e+00, 0.e+00],
-      [ 0.e+00 ,0.e+00, 0.e+00, 0.e+00, 0.e+00,
        0.e+00, 1.e+00, 0.e+00, 0.e+00, 0.e+00],
       [0.e+00, 0.e+00, 0.e+00, 0.e+00, 0.e+00,
-       0.e+00, 0.e+00, 0.e+00, 5.e-07, 1.e+00],
+       0.e+00, 0.e+00, 0.e+00, 0.e+00, 1.e+00],
       [0.e+00, 0.e+00, 0.e+00, 0.e+00, 0.e+00,
-       0.e+00 ,1.e+00, 0.e+00, 0.e+00, 0.e+00],
+       0.e+00, 1.e+00, 0.e+00, 0.e+00, 0.e+00],
       [0.e+00, 1.e+00, 0.e+00, 0.e+00, 0.e+00,
-       0.e+00 ,0.e+00, 0.e+00, 0.e+00, 0.e+00],
+       0.e+00, 0.e+00, 0.e+00, 0.e+00, 0.e+00],
       [0.e+00, 0.e+00, 0.e+00, 0.e+00, 1.e+00,
        0.e+00, 0.e+00, 0.e+00, 0.e+00, 0.e+00],
       [0.e+00, 0.e+00, 0.e+00, 0.e+00, 0.e+00,
@@ -157,23 +159,37 @@ def test_qnetwork():
   actual_output = model.predict(inputs).astype(np.float16)
   assert_allclose(actual_output, expected_output, rtol=1e-4)
 
-
-def test_qconv1d():
+@pytest.mark.parametrize("layer_cls", ["QConv1D", "QSeparableConv1D"])
+def test_qconv1d(layer_cls):
   np.random.seed(33)
-  x = Input((4, 4,))
-  y = QConv1D(
+  if layer_cls == "QConv1D":
+    x = Input((4, 4,))
+    y = QConv1D(
       2, 1,
       kernel_quantizer=quantized_bits(6, 2, 1, alpha=1.0),
       bias_quantizer=quantized_bits(4, 0, 1),
       name='qconv1d')(
           x)
-  model = Model(inputs=x, outputs=y)
+    model = Model(inputs=x, outputs=y)
+  else:
+    x = Input((4, 4,))
+    y = QSeparableConv1D(
+      2, 2,
+      depthwise_quantizer=quantized_bits(6, 2, 1, alpha=1.0),
+      pointwise_quantizer=quantized_bits(4, 0, 1, alpha=1.0),
+      bias_quantizer=quantized_bits(4, 0, 1),
+      name='qsepconv1d')(
+          x)
+    model = Model(inputs=x, outputs=y)
 
   # Extract model operations
   model_ops = extract_model_operations(model)
 
-  # Assertion about the number of operations for this Conv1D layer
-  assert model_ops['qconv1d']['number_of_operations'] == 32
+  # Assertion about the number of operations for this (Separable)Conv1D layer
+  if layer_cls == "QConv1D":
+    assert model_ops['qconv1d']['number_of_operations'] == 32
+  else:
+    assert model_ops['qsepconv1d']['number_of_operations'] == 30
 
   # Print qstats to make sure it works with Conv1D layer
   print_qstats(model)
@@ -212,11 +228,16 @@ def test_qconv1d():
 
   inputs = np.random.rand(2, 4, 4)
   p = model.predict(inputs).astype(np.float16)
-  y = np.array([[[-2.441, 3.816], [-3.807, -1.426], [-2.684, -1.317],
-                 [-1.659, 0.9834]],
-                [[-4.99, 1.139], [-2.559, -1.216], [-2.285, 1.905],
-                 [-2.652, -0.467]]]).astype(np.float16)
-  assert np.all(p == y)
+  if layer_cls == "QConv1D":
+    y = np.array([[[-2.441, 3.816], [-3.807, -1.426], [-2.684, -1.317],
+                   [-1.659, 0.9834]],
+                  [[-4.99, 1.139], [-2.559, -1.216], [-2.285, 1.905],
+                   [-2.652, -0.467]]]).astype(np.float16)
+  else:
+    y = np.array([[[-2.275,   -3.178], [-0.4358, -3.262], [ 1.987,  0.3987]],
+                  [[-0.01251, -0.376], [ 0.3928, -1.328], [-1.243, -2.43  ]]]
+                ).astype(np.float16)
+  assert_allclose(p, y, rtol=1e-4)
 
 def test_qconv2dtranspose():
   x = Input((4, 4, 1,))


### PR DESCRIPTION
This PR adds `QSeparableConv1D` and `QSeparableConv2D`. The existing `QSeparableConv2D` (which expands to `QDepthwiseConv2D` and 1x1 `QConv2D`) that is based on MobileNet is retained and renamed `QMobileNetSeparableConv2D`  