### PR TITLE
QConv2DBatchnorm: propagate batchnorm parameters and fix name

### DIFF
--- a/qkeras/qconv2d_batchnorm.py
+++ b/qkeras/qconv2d_batchnorm.py
@@ -79,7 +79,6 @@ class QConv2DBatchnorm(QConv2D):
       trainable=True,
       virtual_batch_size=None,
       adjustment=None,
-      name=None,
 
       # other params
       ema_freeze_delay=None,
@@ -126,8 +125,7 @@ class QConv2DBatchnorm(QConv2D):
         kernel_constraint=kernel_constraint,
         bias_constraint=bias_constraint,
         kernel_quantizer=kernel_quantizer,
-        bias_quantizer=bias_quantizer,
-        name=name)
+        bias_quantizer=bias_quantizer)
 
     # initialization of batchnorm part of the composite layer
     self.batchnorm = layers.BatchNormalization(
@@ -139,7 +137,9 @@ class QConv2DBatchnorm(QConv2D):
         beta_regularizer=beta_regularizer,
         gamma_regularizer=gamma_regularizer,
         beta_constraint=beta_constraint, gamma_constraint=gamma_constraint,
-        fused=False)
+        renorm=renorm, renorm_clipping=renorm_clipping, 
+        renorm_momentum=renorm_momentum, fused=fused, trainable=trainable,
+        virtual_batch_size=virtual_batch_size, adjustment=adjustment)
 
     self.ema_freeze_delay = ema_freeze_delay
     assert folding_mode in ["ema_stats_folding", "batch_stats_folding"]

--- a/qkeras/qconv2d_batchnorm.py
+++ b/qkeras/qconv2d_batchnorm.py
@@ -125,7 +125,8 @@ class QConv2DBatchnorm(QConv2D):
         kernel_constraint=kernel_constraint,
         bias_constraint=bias_constraint,
         kernel_quantizer=kernel_quantizer,
-        bias_quantizer=bias_quantizer)
+        bias_quantizer=bias_quantizer,
+        **kwargs)
 
     # initialization of batchnorm part of the composite layer
     self.batchnorm = layers.BatchNormalization(

--- a/qkeras/qdepthwiseconv2d_batchnorm.py
+++ b/qkeras/qdepthwiseconv2d_batchnorm.py
@@ -75,7 +75,6 @@ class QDepthwiseConv2DBatchnorm(QDepthwiseConv2D):
       trainable=True,
       virtual_batch_size=None,
       adjustment=None,
-      name=None,
 
       # other params
       ema_freeze_delay=None,
@@ -128,7 +127,7 @@ class QDepthwiseConv2DBatchnorm(QDepthwiseConv2D):
         bias_quantizer=bias_quantizer,
         depthwise_range=depthwise_range,
         bias_range=bias_range,
-        name=name)
+        **kwargs)
 
     # initialization of batchnorm part of the composite layer
     self.batchnorm = layers.BatchNormalization(
@@ -139,9 +138,10 @@ class QDepthwiseConv2DBatchnorm(QDepthwiseConv2D):
         moving_variance_initializer=moving_variance_initializer,
         beta_regularizer=beta_regularizer,
         gamma_regularizer=gamma_regularizer,
-        beta_constraint=beta_constraint,
-        gamma_constraint=gamma_constraint,
-        fused=False)
+        beta_constraint=beta_constraint, gamma_constraint=gamma_constraint,
+        renorm=renorm, renorm_clipping=renorm_clipping, 
+        renorm_momentum=renorm_momentum, fused=fused, trainable=trainable,
+        virtual_batch_size=virtual_batch_size, adjustment=adjustment)
 
     self.ema_freeze_delay = ema_freeze_delay
     assert folding_mode in ["ema_stats_folding", "batch_stats_folding"]

--- a/tests/bn_folding_test.py
+++ b/tests/bn_folding_test.py
@@ -269,7 +269,7 @@ def test_unfold_model():
         strides=(1, 1),
         use_bias=False,
         depthwise_quantizer=kernel_quantizer,
-        folded_mode=folding_mode,
+        folding_mode=folding_mode,
         ema_freeze_delay=ema_freeze_delay,
         name="folddepthwiseconv2d")(x)
     model = Model(inputs=[x_in], outputs=[x])


### PR DESCRIPTION
This PR does two things
- correctly propagates batchnorm parameters (I was seeing a diverging nan loss after 1 epoch without this change)
- leave `name` unspecified so it can be automatically assigned in case the user forgets to specify (`name=None` actually causes an error)