### PR TITLE
Fix QGRU

### DIFF
--- a/qkeras/qrecurrent.py
+++ b/qkeras/qrecurrent.py
@@ -1084,7 +1084,7 @@ class QGRUCell(GRUCell):
     if self.recurrent_quantizer:
       quantized_recurrent = self.recurrent_quantizer_internal(self.recurrent_kernel)
     else:
-      quantized_recurrent = self.kernel
+      quantized_recurrent = self.recurrent_kernel
 
     if self.use_bias:
       if self.bias_quantizer:


### PR DESCRIPTION
This pull request fixes issue #72 

The issue was that the normal kernel was used as the recurrent one when recurrent quantizer was not defined.
