### PR TITLE
Use `delta()` instead of `max() * 2^-bits` when `delta()` is defined

### DIFF
--- a/qkeras/qlayers.py
+++ b/qkeras/qlayers.py
@@ -103,7 +103,10 @@ class QInitializer(Initializer):
 
     max_x = np.max(abs(x))
     std_x = np.std(x)
-    delta = self.quantizer.max() * 2**-self.quantizer.bits
+    if hasattr(self.quantizer, 'delta') and callable(getattr(self.quantizer, 'delta')):
+      delta = self.quantizer.delta()
+    else:
+      delta = self.quantizer.max() * 2**-self.quantizer.bits
 
     # delta is the minimum resolution of the number system.
     # we want to make sure we have enough values.


### PR DESCRIPTION
I'm working on floating point quantizer and I think this line doesn't work in my case:
`delta = self.quantizer.max() * 2**-self.quantizer.bits`
With the modification proposed one can define `delta()` in the quantizer class and use it instead of make the computation in the initializer.