### PR TITLE
removed the integer and bits scaling in quantized bits for alpha=auto and alpha=auto_po2

### DIFF
--- a/qkeras/quantizers.py
+++ b/qkeras/quantizers.py
@@ -1409,8 +1409,6 @@ class quantized_bits(BaseQuantizer):  # pylint: disable=invalid-name
       else:
         axis = [0]
 
-      x = x / m_i
-
       # Using 2's complement, we can represent 2**(bits-1)-1 positive values
       # If we wish to maintain symmetry, we can double 2**(bits-1)-1 to get
       # the total number of possible values we can represent.
@@ -1444,7 +1442,6 @@ class quantized_bits(BaseQuantizer):  # pylint: disable=invalid-name
         raise ValueError(f"Invalid alpha '{self.alpha}'")
 
       # z is an integer number, so we must make the scale * m and z / m
-      scale = scale * m
 
       # we will not use "z" right now because of stochastic_rounding
       # this is still under test.
@@ -1453,8 +1450,7 @@ class quantized_bits(BaseQuantizer):  # pylint: disable=invalid-name
       #  z = z / m
       #  self.scale = scale
       #  return x + tf.stop_gradient(-x + scale * z)
-      x = m_i * x
-      xq = m_i * z / m
+      xq = z
       self.scale = scale
       xq = scale * xq
 


### PR DESCRIPTION
In the quantized_bits class, when alpha=auto or alpha=auto_po2, the unquantized value "x" is manipulated in a strange way. Even if the number of integer bits is not considered when scaling with alpha=auto and alpha=auto_po2, "x" is divided by m_i (, namely 2**integer_bits) to be later remultiplied by the same value m_i. As x is originally divided by m_i, z (which depends on x) is later multiplied by m_i and divided by m. In order to adjust for the division by m, the scale factor (which multiplies z) is multiplied by m.

I removed the m_i and m references in the code as they don't matter when considering alpha=auto or alpha=auto_po2. I also tested this new version of the quantizer with older versions and the result is the same.