### PR TITLE
take unstack from array_ops_stack, not directly from array_ops

### DIFF
--- a/qkeras/qrecurrent.py
+++ b/qkeras/qrecurrent.py
@@ -1125,7 +1125,7 @@ class QGRUCell(GRUCell):
       if not self.reset_after:
         input_bias, recurrent_bias = quantized_bias, None
       else:
-        input_bias, recurrent_bias = array_ops.unstack(quantized_bias)
+        input_bias, recurrent_bias = array_ops.array_ops_stack.unstack(quantized_bias)
 
     if self.implementation == 1:
       if 0. < self.dropout < 1.:


### PR DESCRIPTION
Starting with tensorflow 2.13 `tensorflow.python.ops.array_ops` no longer has `unstack`. One must take it from array_ops_stack. (The alternate fix would be to import `tensorflow.python.ops.array_ops_stack` separately.